### PR TITLE
Create release only  if it doesn't already exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Several environment variables are needed:
 
 Then add this buildpack to your app:
 
-    heroku buildpacks:add https://github.com/Schnouki/buildpack-sentry-sourcemaps
+    heroku buildpacks:add https://github.com/Freshly/buildpack-sentry-sourcemaps
 
 And push a new relase.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Several environment variables are needed:
   URL (`https://example.com/dist/js/`) or a tilde-based prefix (`~/dist/js/`,
   see the [documentation][docs] for details). Make sure to include the final
   slash if it's needed.
-- `SOURCEMAP_SENTRY_ORG`: the organization to search against for releases
 
 Then add this buildpack to your app:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Several environment variables are needed:
   URL (`https://example.com/dist/js/`) or a tilde-based prefix (`~/dist/js/`,
   see the [documentation][docs] for details). Make sure to include the final
   slash if it's needed.
+- `SOURCEMAP_SENTRY_ORG`: the organization to search against for releases
 
 Then add this buildpack to your app:
 

--- a/bin/compile
+++ b/bin/compile
@@ -23,8 +23,26 @@ fi
 
 API="https://sentry.io/api/0/projects/${SOURCEMAP_SENTRY_PROJECT}"
 
-# Create a release
-echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"
+# Find or create the release
+ORG_API="https://sentry.io/api/0/organizations/${SOURCEMAP_SENTRY_ORG}"
+
+RELEASE_NAME=$(curl -sSf "${ORG_API}/releases/" \
+  -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
+  | ruby -e "require 'json';\
+      release_name=JSON.load(STDIN.read).find do |r|; \
+        r['ref'] == '${SOURCE_VERSION}' && \
+          r['projects'].any? { |pr| pr['slug'] == '${SOURCEMAP_SENTRY_ORG}'};
+      end; \
+  STDOUT.puts URI.encode(release_name['version']) if release_name"
+)
+
+if [[ -z $RELEASE_NAME ]]; then
+  RELEASE_NAME=$SOURCE_VERSION
+fi
+
+
+
+echo "-----> Creating Sentry release ${RELEASE_NAME} for project ${SOURCEMAP_SENTRY_PROJECT}"
 
 curl -sSf "${API}/releases/" \
   -X POST \
@@ -50,7 +68,7 @@ for map in *.js.map; do
 
     if [[ "${res[0]}" == "" ]]; then
         echo "       Uploading ${map} to Sentry"
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
+        curl -sSf "${API}/releases/${RELEASE_NAME}/files/" \
              -X POST \
              -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
              -F file=@"${map}" \
@@ -59,11 +77,11 @@ for map in *.js.map; do
 
     elif [[ "${res[1]}" != "${sum}" ]]; then
         echo "       Updating ${map} on Sentry"
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/${res[0]}/" \
+        curl -sSf "${API}/releases/${RELEASE_NAME}/files/${res[0]}/" \
              -X DELETE \
              -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
              >/dev/null
-        curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
+        curl -sSf "${API}/releases/${RELEASE_NAME}/files/" \
              -X POST \
              -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
              -F file=@"${map}" \

--- a/bin/compile
+++ b/bin/compile
@@ -25,6 +25,7 @@ API="https://sentry.io/api/0/projects/${SOURCEMAP_SENTRY_PROJECT}"
 
 # Find or create the release
 ORG=$(echo $SOURCEMAP_SENTRY_PROJECT | cut -d/ -f1)
+PROJECT=$(echo $SOURCEMAP_SENTRY_PROJECT | cut -d/ -f2)
 ORG_API="https://sentry.io/api/0/organizations/${ORG}"
 
 echo "-----> Searching for Sentry release referring to ${SOURCE_VERSION} for organization ${ORG}"
@@ -35,7 +36,7 @@ RELEASE_NAME=$(curl -sSf "${ORG_API}/releases/" \
       return if res == ''; \
       release_name=JSON.load(res).find do |r|; \
         r['ref'] == '${SOURCE_VERSION}' && \
-          r['projects'].any? { |pr| pr['slug'] == '${ORG}'}; \
+          r['projects'].any? { |pr| pr['slug'] == '${PROJECT}'}; \
       end; \
   STDOUT.puts URI.encode(release_name['version']) if release_name"
 )

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ RELEASE_NAME=$(curl -sSf "${ORG_API}/releases/" \
       return if res == ''; \
       release_name=JSON.load(res).find do |r|; \
         r['ref'] == '${SOURCE_VERSION}' && \
-          r['projects'].any? { |pr| pr['slug'] == '${SOURCEMAP_SENTRY_ORG}'}; \
+          r['projects'].any? { |pr| pr['slug'] == '${ORG}'}; \
       end; \
   STDOUT.puts URI.encode(release_name['version']) if release_name"
 )

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_URL_PREFIX; do
+for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_SENTRY_ORG SOURCEMAP_URL_PREFIX; do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done

--- a/bin/compile
+++ b/bin/compile
@@ -27,32 +27,33 @@ API="https://sentry.io/api/0/projects/${SOURCEMAP_SENTRY_PROJECT}"
 ORG=$(echo $SOURCEMAP_SENTRY_PROJECT | cut -d/ -f1)
 ORG_API="https://sentry.io/api/0/organizations/${ORG}"
 
+echo "-----> Searching for Sentry release referring to ${SOURCE_VERSION} for organization ${ORG}"
 RELEASE_NAME=$(curl -sSf "${ORG_API}/releases/" \
   -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
   | ruby -e "require 'json';\
-      res=STDIN.read
-      return if res == ''
+      res=STDIN.read; \
+      return if res == ''; \
       release_name=JSON.load(res).find do |r|; \
         r['ref'] == '${SOURCE_VERSION}' && \
-          r['projects'].any? { |pr| pr['slug'] == '${SOURCEMAP_SENTRY_ORG}'};
+          r['projects'].any? { |pr| pr['slug'] == '${SOURCEMAP_SENTRY_ORG}'}; \
       end; \
   STDOUT.puts URI.encode(release_name['version']) if release_name"
 )
 
-if [[ -z $RELEASE_NAME ]]; then
+if [[ -n $RELEASE_NAME ]]; then
+  echo "-----> Found Sentry release ${RELEASE_NAME} for ${ORG}"
+else
   RELEASE_NAME=$SOURCE_VERSION
+  echo "-----> No Sentry release found for ${SOURCE_VERSION} in ${ORG}"
+  echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"
+
+  curl -sSf "${API}/releases/" \
+    -X POST \
+    -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d "{\"version\": \"${SOURCE_VERSION}\"}" \
+    >/dev/null
 fi
-
-
-
-echo "-----> Creating Sentry release ${RELEASE_NAME} for project ${SOURCEMAP_SENTRY_PROJECT}"
-
-curl -sSf "${API}/releases/" \
-  -X POST \
-  -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
-  -H 'Content-Type: application/json' \
-  -d "{\"version\": \"${SOURCE_VERSION}\"}" \
-  >/dev/null
 
 # Retrieve files
 files=$(mktemp)

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_SENTRY_ORG SOURCEMAP_URL_PREFIX; do
+for key in SOURCEMAP_DIR SOURCEMAP_SENTRY_TOKEN SOURCEMAP_SENTRY_PROJECT SOURCEMAP_URL_PREFIX; do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done
@@ -24,12 +24,15 @@ fi
 API="https://sentry.io/api/0/projects/${SOURCEMAP_SENTRY_PROJECT}"
 
 # Find or create the release
-ORG_API="https://sentry.io/api/0/organizations/${SOURCEMAP_SENTRY_ORG}"
+ORG=$(echo $SOURCEMAP_SENTRY_PROJECT | cut -d/ -f1)
+ORG_API="https://sentry.io/api/0/organizations/${ORG}"
 
 RELEASE_NAME=$(curl -sSf "${ORG_API}/releases/" \
   -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
   | ruby -e "require 'json';\
-      release_name=JSON.load(STDIN.read).find do |r|; \
+      res=STDIN.read
+      return if res == ''
+      release_name=JSON.load(res).find do |r|; \
         r['ref'] == '${SOURCE_VERSION}' && \
           r['projects'].any? { |pr| pr['slug'] == '${SOURCEMAP_SENTRY_ORG}'};
       end; \

--- a/bin/compile
+++ b/bin/compile
@@ -45,21 +45,21 @@ if [[ -n $RELEASE_NAME ]]; then
   echo "-----> Found Sentry release ${RELEASE_NAME} for ${ORG}"
 else
   RELEASE_NAME=$SOURCE_VERSION
-  echo "-----> No Sentry release found for ${SOURCE_VERSION} in ${ORG}"
-  echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"
+  echo "-----> No Sentry release found for ${RELEASE_NAME} in ${ORG}"
+  echo "-----> Creating Sentry release ${RELEASE_NAME} for project ${SOURCEMAP_SENTRY_PROJECT}"
 
   curl -sSf "${API}/releases/" \
     -X POST \
     -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"version\": \"${SOURCE_VERSION}\"}" \
+    -d "{\"version\": \"${RELEASE_NAME}\"}" \
     >/dev/null
 fi
 
 # Retrieve files
 files=$(mktemp)
 echo "       Retrieving existing files to $files"
-curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
+curl -sSf "${API}/releases/${RELEASE_NAME}/files/" \
      -X GET \
      -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
      > "$files"


### PR DESCRIPTION
Yet to be tested, this will use a release if one already exists for that ref. This is because creating a release the way it currently does doesn't help us much.