### PR TITLE
Set REVISION file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -38,28 +38,30 @@ RELEASE_NAME=$(curl -sSf "${ORG_API}/releases/" \
         r['ref'] == '${SOURCE_VERSION}' && \
           r['projects'].any? { |pr| pr['slug'] == '${PROJECT}'}; \
       end; \
-  STDOUT.puts URI.encode(release_name['version']) if release_name"
+  STDOUT.puts release_name['version'] if release_name"
 )
 
 if [[ -n $RELEASE_NAME ]]; then
   echo "-----> Found Sentry release ${RELEASE_NAME} for ${ORG}"
+  ENCODED_RELEASE_NAME=$(ruby -e "STDOUT.puts URI.encode(ARGV[0])" "${RELEASE_NAME}")
 else
   RELEASE_NAME=$SOURCE_VERSION
-  echo "-----> No Sentry release found for ${RELEASE_NAME} in ${ORG}"
-  echo "-----> Creating Sentry release ${RELEASE_NAME} for project ${SOURCEMAP_SENTRY_PROJECT}"
+  ENCODED_RELEASE_NAME=$SOURCE_VERSION
+  echo "-----> No Sentry release found for ${SOURCE_VERSION} in ${ORG}"
+  echo "-----> Creating Sentry release ${SOURCE_VERSION} for project ${SOURCEMAP_SENTRY_PROJECT}"
 
   curl -sSf "${API}/releases/" \
     -X POST \
     -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
     -H 'Content-Type: application/json' \
-    -d "{\"version\": \"${RELEASE_NAME}\"}" \
+    -d "{\"version\": \"${SOURCE_VERSION}\"}" \
     >/dev/null
 fi
 
 # Retrieve files
 files=$(mktemp)
 echo "       Retrieving existing files to $files"
-curl -sSf "${API}/releases/${RELEASE_NAME}/files/" \
+curl -sSf "${API}/releases/${ENCODED_RELEASE_NAME}/files/" \
      -X GET \
      -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
      > "$files"
@@ -73,7 +75,7 @@ for map in *.js.map; do
 
     if [[ "${res[0]}" == "" ]]; then
         echo "       Uploading ${map} to Sentry"
-        curl -sSf "${API}/releases/${RELEASE_NAME}/files/" \
+        curl -sSf "${API}/releases/${ENCODED_RELEASE_NAME}/files/" \
              -X POST \
              -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
              -F file=@"${map}" \
@@ -82,11 +84,11 @@ for map in *.js.map; do
 
     elif [[ "${res[1]}" != "${sum}" ]]; then
         echo "       Updating ${map} on Sentry"
-        curl -sSf "${API}/releases/${RELEASE_NAME}/files/${res[0]}/" \
+        curl -sSf "${API}/releases/${ENCODED_RELEASE_NAME}/files/${res[0]}/" \
              -X DELETE \
              -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
              >/dev/null
-        curl -sSf "${API}/releases/${RELEASE_NAME}/files/" \
+        curl -sSf "${API}/releases/${ENCODED_RELEASE_NAME}/files/" \
              -X POST \
              -H "Authorization: Bearer ${SOURCEMAP_SENTRY_TOKEN}" \
              -F file=@"${map}" \
@@ -97,6 +99,12 @@ for map in *.js.map; do
         echo "       ${map} is up-to-date"
     fi
 done
+
+# Set the release version so dyno metadata doesn't ruin everything above
+# https://docs.sentry.io/clients/ruby/config/#optional-settings and see 'releases'
+echo "-----> Setting Sentry REVISION file to ${RELEASE_NAME}"
+BUILD_DIR=$1
+echo $RELEASE_NAME > $BUILD_DIR/REVISION
 
 rm "${files}"
 


### PR DESCRIPTION
If Heroku Dyno Metadata is enabled, when a dyno starts Sentry will automagically use the magic Heroku metadata `SOURCE_VERSION`. If this happens, all the work previously done will be undone and Sentry will continue to use the old SHA release format.

See: https://docs.sentry.io/clients/ruby/config/#optional-settings
And go to the `releases` to see the configuration options and the load priority.