### PR TITLE
Add SOURCE_VERSION file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -112,6 +112,7 @@ done
 echo "-----> Setting Sentry REVISION file to ${RELEASE_NAME}"
 BUILD_DIR=$1
 echo $RELEASE_NAME > $BUILD_DIR/REVISION
+echo $SOURCE_VERSION > $BUILD_DIR/SOURCE_VERSION
 
 rm "${files}"
 


### PR DESCRIPTION
Heroku Dyno Metadata cannot be enabled for all apps, so this gets around that for some scenarios.